### PR TITLE
Fix Next.js and Sass warnings, remove Fathom

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "node": ">=24 <25"
   },
   "dependencies": {
-    "fathom-client": "^3.2.0",
     "leaflet": "^1.9.4",
     "next": "^16.2.9",
     "react": "^19.2.7",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,31 +1,10 @@
 import Head from 'next/head';
 import { AppProps } from 'next/app';
-import { useRouter } from 'next/router';
-import { useEffect } from 'react';
-import * as Fathom from 'fathom-client';
 import 'leaflet/dist/leaflet.css';
 
 import '../styles/global.scss';
 
 function MyApp({ Component, pageProps }: AppProps) {
-  const router = useRouter();
-
-  useEffect(() => {
-    Fathom.load('XRUGMNZE', {
-      includedDomains: ['papercups.mamuso.net'],
-    });
-
-    const onRouteChangeComplete = () => {
-      Fathom.trackPageview();
-    };
-
-    router.events.on('routeChangeComplete', onRouteChangeComplete);
-
-    return () => {
-      router.events.off('routeChangeComplete', onRouteChangeComplete);
-    };
-  }, [router.events]);
-
   return (
     <>
       <Head>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -33,7 +33,6 @@ function MyApp({ Component, pageProps }: AppProps) {
         <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
         <meta name="author" content="mamuso" />
         <link rel="icon" type="image/png" href="/favicon.png" />
-        <link rel="stylesheet" href="/leaflet-fixes.css" />
       </Head>
       <Component {...pageProps} />
     </>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,7 +6,9 @@ class MyDocument extends Document {
 
     return (
       <Html lang="en">
-        <Head />
+        <Head>
+          <link rel="stylesheet" href="/leaflet-fixes.css" />
+        </Head>
         <body>
           <Main />
           <NextScript />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      fathom-client:
-        specifier: ^3.2.0
-        version: 3.7.2
       leaflet:
         specifier: ^1.9.4
         version: 1.9.4
@@ -1132,9 +1129,6 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
-
-  fathom-client@3.7.2:
-    resolution: {integrity: sha512-sWtaNivhg7uwp/q1bUuIiNj4LeQZMEZ5NXXFFpZ8le4uDedAfQG84gPOdYehtVXbl+1yX2s8lmXZ2+IQ9a/xxA==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3095,8 +3089,6 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
-
-  fathom-client@3.7.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -1,6 +1,6 @@
-@import './variables';
-
-@import './reset';
+@use "sass:color";
+@use './variables' as *;
+@use './reset';
 
 /* 
   Importing fonts
@@ -112,7 +112,7 @@ main {
     margin-bottom: 4.6rem;
     position: relative;
     address {
-      background-color: transparentize(#fff, 0.35);
+      background-color: color.adjust(#fff, $alpha: -0.35);
       border-radius: $radii-small;
       color: $color-lighttext;
       margin: -2.2rem 0 0 -2rem;

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 /*
   Font
 */
@@ -22,11 +24,11 @@ $radii-small: 0.6rem;
   Color
 */
 $color-bodytext: #2d2e37;
-$color-lighttext: transparentize($color-bodytext, 0.5);
+$color-lighttext: color.adjust($color-bodytext, $alpha: -0.5);
 $color-gray-1: #d6d6d0;
-$color-gray-2: desaturate(darken($color-gray-1, 10%), 4%);
-$color-gray-3: transparentize($color-gray-2, 0.4);
-$color-gray-4: desaturate(darken($color-gray-1, 15%), 4%);
+$color-gray-2: color.adjust(color.adjust($color-gray-1, $lightness: -10%), $saturation: -4%);
+$color-gray-3: color.adjust($color-gray-2, $alpha: -0.4);
+$color-gray-4: color.adjust(color.adjust($color-gray-1, $lightness: -15%), $saturation: -4%);
 
 /*
   Noise mixing


### PR DESCRIPTION
## Summary
- Move `leaflet-fixes.css` from `next/head` to `_document` to resolve the Next.js stylesheet warning
- Remove Fathom analytics integration and `fathom-client` dependency
- Migrate Sass from deprecated `@import` and global color functions to `@use` and `sass:color`

## Test plan
- [ ] Run `pnpm dev` and confirm no Sass or `next/head` stylesheet warnings in the terminal
- [ ] Visit a pour page (e.g. `/pour/dune-santa-barbara-usa`) and verify the map renders correctly
- [ ] Run `pnpm build` and confirm a clean production build


Made with [Cursor](https://cursor.com)